### PR TITLE
Drastically improve performance

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -78,3 +78,11 @@ jobs:
         RAILS_ENV: test
       run: |
         bundle exec rails test:system
+    - name: Run benchmarks
+      env:
+        PGHOST: 127.0.0.1
+        PGUSER: postgres
+        PGPASSWORD: postgres
+        RAILS_ENV: test
+      run: |
+        bin/benchmark

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "sidekiq", ">= 7.0.8"
 gem "sidekiq-cron"
 gem "fugit"
 gem "rails-i18n", ">= 7.0.7"
+gem "parallel"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
+    parallel (1.23.0)
     pg (1.5.3)
     public_suffix (5.0.3)
     puma (6.3.0)
@@ -251,6 +252,7 @@ DEPENDENCIES
   fugit
   importmap-rails (>= 1.1.6)
   jbuilder
+  parallel
   pg (~> 1.1)
   puma (~> 6.0)
   rails (~> 7, >= 7.0.5.1)

--- a/app/jobs/sender/process_payload_job.rb
+++ b/app/jobs/sender/process_payload_job.rb
@@ -17,41 +17,12 @@ module Sender
   class ProcessPayloadJob < ApplicationJob
     queue_as :default
 
-    PAYLOAD_LOAD_PROGRESS = 10.0
-    DIFF_PROGRESS = 40.0
-    COPYING_PROGRESS = 50.0
-
     def perform(sync, source_path, target_path)
       sync.start!
 
       payload_files = sync.sender_payload.load[:files]
-      sync.increment(:progress, PAYLOAD_LOAD_PROGRESS)
-      sync.save
-
-      Dir.chdir(source_path) do
-        source_files = Dir.glob("**/*").select(&File.method(:file?))
-        source_files_count = source_files.count
-        files_to_copy = source_files.each_with_object([]) do |file, memo|
-          sync.increment(:progress, (1.0 / source_files_count * DIFF_PROGRESS))
-          sync.save
-
-          memo << file if !payload_files.key?(file) || payload_files[file] < File.mtime(file).to_i
-          memo
-        end
-
-        files_to_copy_count = files_to_copy.count
-        files_to_copy.each do |file|
-          `rsync -Rt #{file} #{target_path}`
-          file_size = File.size(file)
-          sync.increment(:bytes_transferred, file_size)
-
-          sync.increment(:progress, (1.0 / files_to_copy_count * COPYING_PROGRESS))
-          sync.sent_files.create(path: file, size: file_size)
-          sync.save
-        end
-
-        sync.increment(:progress, COPYING_PROGRESS) if files_to_copy.empty?
-      end
+      files_to_send = Sender::Diff.diff(source_path, payload_files)
+      Sender::Send.send(source_path, files_to_send, target_path, sync)
 
       sync.finish!
     rescue StandardError => e

--- a/app/models/receiver/payload.rb
+++ b/app/models/receiver/payload.rb
@@ -9,8 +9,8 @@ module Receiver
     scope :ordered, -> { order(sent_at: :desc) }
     before_create :generate_uid
 
-    def self.generate(uid)
-      files = Dir.chdir(Config.get!(:receiver_storage_folder)) do
+    def self.generate(uid, path: Config.get!(:receiver_storage_folder))
+      files = Dir.chdir(path) do
         Dir.glob("**/*").select(&File.method(:file?)).each_with_object({}) do |file, memo|
           memo[file] = File.mtime(file).to_i
           memo

--- a/app/models/sender/diff.rb
+++ b/app/models/sender/diff.rb
@@ -1,0 +1,14 @@
+module Sender
+  class Diff
+    def self.diff(source_path, payload_files)
+      Dir.chdir(source_path) do
+        source_files = Dir.glob("**/*").select(&File.method(:file?))
+
+        source_files.each_with_object([]) do |file, memo|
+          memo << file if !payload_files.key?(file) || payload_files[file] < File.mtime(file).to_i
+          memo
+        end
+      end
+    end
+  end
+end

--- a/app/models/sender/send.rb
+++ b/app/models/sender/send.rb
@@ -1,0 +1,26 @@
+module Sender
+  class Send
+    def self.send(source_path, files, target_path, sync)
+      Dir.chdir(source_path) do
+        files_count = files.count
+        sent_files = []
+        progress_step = (1.0 / files_count * 100.0)
+        progress = 0.0
+        finish = Proc.new do |file|
+          progress += progress_step
+          sync.progress = progress.round
+          sync.increment(:bytes_transferred, File.size(file))
+          sync.save if sync.progress_changed?
+        end
+        sent_files = Parallel.map_with_index(files, finish: finish) do |file, index|
+          `rsync -Rt #{file} #{target_path}`
+          { path: file, size: File.size(file), sync_id: sync.id}
+        end
+        SentFile.insert_all(sent_files)
+        sync.save
+      end
+
+      sync.increment(:progress, COPYING_PROGRESS) if files.empty?
+    end
+  end
+end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+SYNCHRONIST_TEST_BENCHMARK=true bin/rails test test/models/benchmark_test.rb

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,37 @@
+require 'fileutils'
+
+def create_directories(base_path, depth, file_count)
+  if depth == 0
+    # Create the files at this level
+    file_count.times do |i|
+      File.write(File.join(base_path, "file_#{i}.txt"), "Content for file #{i}")
+    end
+    return
+  end
+
+  # Number of directories at this level
+  dir_count = 5
+
+  # Distribute files evenly across directories
+  files_per_dir = file_count / dir_count
+
+  dir_count.times do |i|
+    dir_path = File.join(base_path, "dir_#{i}")
+    FileUtils.mkdir_p(dir_path)
+    create_directories(dir_path, depth - 1, files_per_dir)
+  end
+end
+
+# Base path where the structure will be created
+base_path = "./test/fixtures/files/benchmark"
+
+# Depth of the directory structure
+depth = 5
+
+# Total number of files to create
+total_files = 100000
+
+# Create the directories and files
+create_directories(base_path, depth, total_files)
+
+puts "Directory structure created successfully."

--- a/test/models/benchmark_test.rb
+++ b/test/models/benchmark_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class BenchmarkTest < ActiveSupport::TestCase
+  BENCHMARK_SOURCE_RELATIVE_PATH = "tmp/benchmark"
+  BENCHMARK_SOURCE_PATH = Rails.root.join(BENCHMARK_SOURCE_RELATIVE_PATH)
+  BENCHMARK_SOURCE_DEPTH = 5
+  BENCHMARK_SOURCE_FILES = 100_000
+  BENCHMARK_SEND_PATH = Rails.root.join("tmp/benchmark-send")
+  BENCHMARK_SEND_SAMPLE_SIZE = 1000
+
+  setup do
+    if ENV.key?("SYNCHRONIST_TEST_BENCHMARK") && !Dir.exist?(BENCHMARK_SOURCE_PATH)
+      print "Generating sample directory (#{BENCHMARK_SOURCE_DEPTH} levels, #{BENCHMARK_SOURCE_FILES} files) in #{BENCHMARK_SOURCE_RELATIVE_PATH} ... "
+      create_directories(BENCHMARK_SOURCE_PATH, BENCHMARK_SOURCE_DEPTH, BENCHMARK_SOURCE_FILES)
+      puts "done"
+      FileUtils.rm_rf BENCHMARK_SEND_PATH
+      FileUtils.mkdir_p BENCHMARK_SEND_PATH
+    end
+  end
+
+  test "benchmark diffing" do
+    skip_unless_benchmarking
+    payload_files = Marshal.load(Receiver::Payload.generate("1234", path: BENCHMARK_SOURCE_PATH))[:files]
+    Benchmark.bm do |x|
+      x.report("Diff files") do
+        Sender::Diff.diff(BENCHMARK_SOURCE_PATH, payload_files)
+      end
+    end
+  end
+
+  test "benchmark send" do
+    skip_unless_benchmarking
+    sync = Sync.create!(sender_payload: Sender::Payload.create!(uid: "1234", mtime: Time.now, received_at: Time.now))
+    files = Marshal.load(Receiver::Payload.generate("1234", path: BENCHMARK_SOURCE_PATH))[:files].keys.first(BENCHMARK_SEND_SAMPLE_SIZE)
+    Benchmark.bm do |x|
+      x.report("Send files") do
+        Sender::Send.send(BENCHMARK_SOURCE_PATH, files, BENCHMARK_SOURCE_PATH, sync)
+      end
+    end
+  end
+
+  private
+  def create_directories(base_path, depth, file_count)
+    if depth == 0
+      # Create the files at this level
+      file_count.times do |i|
+        File.write(File.join(base_path, "file_#{i}.txt"), "Content for file #{i}")
+      end
+      return
+    end
+
+    # Number of directories at this level
+    dir_count = BENCHMARK_SOURCE_DEPTH
+
+    # Distribute files evenly across directories
+    files_per_dir = file_count / dir_count
+
+    dir_count.times do |i|
+      dir_path = File.join(base_path, "dir_#{i}")
+      FileUtils.mkdir_p(dir_path)
+      create_directories(dir_path, depth - 1, files_per_dir)
+    end
+  end
+
+  def skip_unless_benchmarking
+    skip "Use bin/benchmark to run benchmarks" unless ENV.key?("SYNCHRONIST_TEST_BENCHMARK")
+  end
+end


### PR DESCRIPTION
- Don't hit the database as much when diffing (> 1000x faster on a sample set of 100'000)
- Use parallel to call rsync when sending files This should improve performance by a lot when sending a lot of small files, but doesn't change the performance on big files as the filesystem will be the limitation here
- Add benchmark tests